### PR TITLE
chore: Add new community into communities.json: ShareIT

### DIFF
--- a/app/community/[id]/page.tsx
+++ b/app/community/[id]/page.tsx
@@ -1,15 +1,19 @@
-import { fetchCommunities } from "@/utils/fetchCommunities"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Globe, Twitter, Github } from "lucide-react"
+import { fetchCommunities } from "@/utils/fetchCommunities";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Globe, Twitter, Github, Linkedin } from "lucide-react";
 
-export default async function CommunityPage({ params }: { params: { id: string } }) {
-  const communities = await fetchCommunities()
-  const community = communities.find((c) => c.id === params.id)
+export default async function CommunityPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const communities = await fetchCommunities();
+  const community = communities.find((c) => c.id === params.id);
 
   if (!community) {
-    return <div>Community not found</div>
+    return <div>Community not found</div>;
   }
 
   return (
@@ -30,7 +34,11 @@ export default async function CommunityPage({ params }: { params: { id: string }
           </a>
         )}
         {community.twitter && (
-          <a href={`https://twitter.com/${community.twitter}`} target="_blank" rel="noopener noreferrer">
+          <a
+            href={`https://twitter.com/${community.twitter}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <Button>
               <Twitter className="mr-2 h-4 w-4" />
               Twitter
@@ -49,16 +57,35 @@ export default async function CommunityPage({ params }: { params: { id: string }
             <CardContent>
               <div className="flex space-x-2">
                 {member.github && (
-                  <a href={`https://github.com/${member.github}`} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={`https://github.com/${member.github}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     <Button variant="outline" size="icon">
                       <Github className="h-4 w-4" />
                     </Button>
                   </a>
                 )}
                 {member.twitter && (
-                  <a href={`https://twitter.com/${member.twitter}`} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={`https://twitter.com/${member.twitter}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     <Button variant="outline" size="icon">
                       <Twitter className="h-4 w-4" />
+                    </Button>
+                  </a>
+                )}
+                {member.linkedin && (
+                  <a
+                    href={`https://www.linkedin.com/in/${member.linkedin}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Button variant="ghost" size="icon" className="h-6 w-6">
+                      <Linkedin className="h-3 w-3" />
                     </Button>
                   </a>
                 )}
@@ -68,6 +95,5 @@ export default async function CommunityPage({ params }: { params: { id: string }
         ))}
       </div>
     </div>
-  )
+  );
 }
-

--- a/public/data/communities.json
+++ b/public/data/communities.json
@@ -127,32 +127,55 @@
       {
         "name": "Elias Velazquez",
         "github": "eliasvelazquezdev",
-        "twitter": "esvdev"
+        "twitter": "esvdev",
+        "linkedin": "eliassvelazquez"
       },
       {
         "name": "Eros Benitez Dos Santos",
         "github": "Shinigamy19",
-        "twitter": ""
+        "twitter": "",
+        "linkedin": "eros-benitez"
+      },
+      {
+        "name": "Natalia Quevedo",
+        "github": "",
+        "twitter": "",
+        "linkedin": "natalia-a-quevedo"
+      },
+      {
+        "name": "Ana Rivarola",
+        "github": "",
+        "twitter": "",
+        "linkedin": "anabelenrivarola"
       },
       {
         "name": "Jean Roa",
         "github": "jeanroadev",
-        "twitter": ""
+        "twitter": "",
+        "linkedin": "jeanmra"
       },
       {
         "name": "Virginia Garcia",
         "github": "virginia-garcia",
-        "twitter": ""
+        "twitter": "",
+        "linkedin": "garcia-virginia"
       },
       {
         "name": "Nicolas Cruz",
         "github": "NicoFJCruz",
-        "twitter": "NicoCruzDev"
+        "twitter": "NicoCruzDev",
+        "linkedin": "nicofj-cruz"
       },
       {
         "name": "Fernando Cardozo",
         "github": "juanignacioboiko",
         "twitter": "f_l_cl"
+      },
+      {
+        "name": "Claudia Metz",
+        "github": "",
+        "twitter": "",
+        "linkedin": "claudia-metz"
       }
     ]
   }

--- a/public/data/communities.json
+++ b/public/data/communities.json
@@ -109,5 +109,51 @@
         "twitter": "mateozaratef"
       }
     ]
+  },
+  {
+    "id": "2",
+    "name": "Share IT",
+    "shortDescription": "Somos una comunidad unida por el deseo de aprender, compartir conocimientos y crecer juntos en el ámbito tecnológico.",
+    "fullDescription": "Share IT es una comunidad de WhatsApp/Discord que reúne a personas de toda índole y de habla hispana, que forman parte o aspiran a formar parte de la industria IT. Nuestro propósito es construir una red de apoyo que permita a sus integrantes progresar como profesionales de esta industria, siempre teniendo en cuenta que la colaboración mutua es el principal motor para un crecimiento sostenible.",
+    "location": {
+      "lat": -34.6131,
+      "lng": -58.3772
+    },
+    "province": "Buenos Aires",
+    "category": "Tech Community",
+    "website": "https://shareit.lat/aboutus/",
+    "twitter": "",
+    "members": [
+      {
+        "name": "Elias Velazquez",
+        "github": "eliasvelazquezdev",
+        "twitter": "esvdev"
+      },
+      {
+        "name": "Eros Benitez Dos Santos",
+        "github": "Shinigamy19",
+        "twitter": ""
+      },
+      {
+        "name": "Jean Roa",
+        "github": "jeanroadev",
+        "twitter": ""
+      },
+      {
+        "name": "Virginia Garcia",
+        "github": "virginia-garcia",
+        "twitter": ""
+      },
+      {
+        "name": "Nicolas Cruz",
+        "github": "NicoFJCruz",
+        "twitter": "NicoCruzDev"
+      },
+      {
+        "name": "Fernando Cardozo",
+        "github": "juanignacioboiko",
+        "twitter": "f_l_cl"
+      }
+    ]
   }
 ]

--- a/types/community.ts
+++ b/types/community.ts
@@ -2,6 +2,7 @@ export interface Member {
   name: string
   github?: string
   twitter?: string
+  linkedin?: string;
 }
 
 export interface Community {


### PR DESCRIPTION
I'd like to know if it's possible to add a LinkedIn field for every item in the `members` list. I'd like to add more members but they don't have either GitHub (they're not devs) or Twitter.

I didn't know what to add to the `category` field, I just wrote "Tech Community", which is redundant given the website nature. Any suggestions there?