### PR TITLE
Fix: Adjusted min card height on community page and province filter

### DIFF
--- a/app/communities/page.tsx
+++ b/app/communities/page.tsx
@@ -278,7 +278,7 @@ export default function CommunitiesPage() {
                 <SelectContent>
                   {provinces.map((province) => (
                     <SelectItem key={province} value={province}>
-                      {province}
+                      {province.charAt(0).toUpperCase() + province.slice(1)}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/app/community/[slug]/CommunityContent.tsx
+++ b/app/community/[slug]/CommunityContent.tsx
@@ -168,12 +168,13 @@ export default function CommunityContent({ community }: CommunityContentProps) {
               whileHover={{ y: -4 }}
               transition={{ duration: 0.2 }}
             >
-              <Card className='group bg-card/50 backdrop-blur-sm border border-border/50 transition-all duration-300 hover:shadow-xl hover:border-primary/50'>
+              <Card className='min-h-[142px] group bg-card/50 backdrop-blur-sm border border-border/50 transition-all duration-300 hover:shadow-xl hover:border-primary/50'>
                 <CardHeader>
                   <CardTitle className='text-lg font-medium'>
                     {member.name}
                   </CardTitle>
                 </CardHeader>
+
                 <CardContent className='flex gap-2'>
                   {member.github && (
                     <Button

--- a/public/data/communities.json
+++ b/public/data/communities.json
@@ -214,6 +214,12 @@
         "github": "",
         "twitter": "",
         "linkedin": "claudia-metz"
+      },
+      {
+        "name": "Hernan Agustin Otero",
+        "github": "guzh09",
+        "twitter": "guzhotero",
+        "linkedin": "hernan-agustin-otero-dev"
       }
     ]
   },


### PR DESCRIPTION
* fix: Adjusted province filter to show 'all' and every province with the first letter uppercased by default.

* fix: Minimum height of member card to account for not having any social.

* Added myself to ShareIT community members
![1](https://github.com/user-attachments/assets/d30f22c0-a82d-46cd-bf7e-c24f327abc90)
![3](https://github.com/user-attachments/assets/83ca7787-7b9c-42e9-bbb2-f7c722f70cc0)
