### PR TITLE
feature - display many communities in an efficient way

### DIFF
--- a/components/ArgentinaMap.tsx
+++ b/components/ArgentinaMap.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import type React from 'react';
-import { useState, useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { AnimatePresence, motion } from 'motion/react';
+import { AnimatePresence, motion } from 'framer-motion';
 import {
   ComposableMap,
   Geographies,
@@ -11,210 +10,278 @@ import {
   Marker,
   ZoomableGroup,
 } from 'react-simple-maps';
+import { geoMercator } from 'd3-geo';
 import { useIsMobile } from '@/hooks/useIsMobile';
-
-import { cn } from '@/lib/utils';
 import type { Community } from '@/types/community';
 
 const geoUrl = '/argentina-provinces.json';
 
-interface ArgentinaMapProps {
-  communities: Community[];
-  onHoverCommunity: (communityId: string | null) => void;
-}
+type TooltipContent =
+  | { type: 'single'; community: Community }
+  | { type: 'cluster'; communities: Community[] };
 
 interface TooltipPosition {
   x: number;
   y: number;
 }
 
-export default function ArgentinaMap({
-  communities,
-  onHoverCommunity,
-}: ArgentinaMapProps) {
+interface ArgentinaMapProps {
+  communities: Community[];
+  onHoverCommunity: (communityId: string | null) => void;
+}
+
+const formatCommunityName = (name: string) => {
+  return name
+    .replace(/[^\w\s]/g, '') // Elimina caracteres no alfanuméricos ni espacios
+    .replace(/\s+/g, '-') // Reemplaza los espacios por guiones
+    .toLowerCase(); // Convierte todo a minúsculas (opcional)
+};
+
+export default function ArgentinaMap({ communities, onHoverCommunity }: ArgentinaMapProps) {
   const router = useRouter();
   const mapRef = useRef<HTMLDivElement>(null);
-  const [tooltipContent, setTooltipContent] = useState<{
-    name: string;
-    location: string;
-  } | null>(null);
-  const [tooltipPosition, setTooltipPosition] = useState<TooltipPosition>({
-    x: 0,
-    y: 0,
-  });
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [tooltipContent, setTooltipContent] = useState<TooltipContent | null>(null);
+  const [tooltipPosition, setTooltipPosition] = useState<TooltipPosition>({ x: 0, y: 0 });
   const isMobile = useIsMobile();
 
-  const handleMarkerClick = useCallback(
-    (communityId: string) => {
-      router.push(`/community/${communityId}`);
-    },
-    [router],
+  // Dimensiones según dispositivo
+  const width = isMobile ? 400 : 800;
+  const height = isMobile ? 300 : 600;
+
+  // Proyección para convertir coordenadas geográficas a píxeles
+  const projection = useMemo(
+    () =>
+      geoMercator()
+        .scale(isMobile ? 400 : 600)
+        .center([-65, -40])
+        .translate([width / 2, height / 2]),
+    [isMobile, width, height]
   );
 
-  const handleMarkerMouseEnter = useCallback(
-    (event: React.MouseEvent<SVGCircleElement>, community: Community) => {
+  // Clusterizamos las comunidades cercanas (en píxeles)
+  const clusters = useMemo(() => {
+    const clusterThreshold = 20; // Ajusta este valor según necesites
+    const clusters: { x: number; y: number; communities: Community[] }[] = [];
+
+    communities.forEach((community) => {
+      if (!community.location) return;
+      const coords = projection([community.location.lng, community.location.lat]);
+      if (!coords) return;
+      let added = false;
+      for (let cluster of clusters) {
+        const dx = coords[0] - cluster.x;
+        const dy = coords[1] - cluster.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        if (distance < clusterThreshold) {
+          cluster.communities.push(community);
+          // Recalcula el centro (promedio)
+          cluster.x = (cluster.x * (cluster.communities.length - 1) + coords[0]) / cluster.communities.length;
+          cluster.y = (cluster.y * (cluster.communities.length - 1) + coords[1]) / cluster.communities.length;
+          added = true;
+          break;
+        }
+      }
+      if (!added) {
+        clusters.push({ x: coords[0], y: coords[1], communities: [community] });
+      }
+    });
+    return clusters;
+  }, [communities, projection]);
+
+  // Muestra el tooltip en la posición del marcador (únicamente con clic/tap)
+  const handleMarkerClick = useCallback(
+    (event: React.MouseEvent<SVGElement>, content: TooltipContent) => {
+      // Evitamos que el clic se propague al contenedor del mapa
+      event.stopPropagation();
       const marker = event.currentTarget;
       const mapContainer = mapRef.current;
-
       if (marker && mapContainer) {
         const markerRect = marker.getBoundingClientRect();
         const mapRect = mapContainer.getBoundingClientRect();
-
         setTooltipPosition({
           x: markerRect.left - mapRect.left + markerRect.width / 2,
           y: markerRect.top - mapRect.top,
         });
-
-        setTooltipContent({
-          name: community.name,
-          location: community.province,
-        });
-
-        onHoverCommunity(community.slug);
+        setTooltipContent(content);
+        if (content.type === 'single') {
+          onHoverCommunity(content.community.slug);
+        } else {
+          onHoverCommunity(null);
+        }
       }
     },
-    [onHoverCommunity],
+    [onHoverCommunity]
   );
 
-  const handleMarkerMouseLeave = useCallback(() => {
+  // Cierra el tooltip
+  const closeTooltip = useCallback(() => {
     setTooltipContent(null);
     onHoverCommunity(null);
   }, [onHoverCommunity]);
 
+  // Navega a la comunidad seleccionada y cierra el tooltip
+  const navigateToCommunity = useCallback(
+    (communityId: string) => {
+      closeTooltip();
+      router.push(`/community/${communityId}`);
+    },
+    [closeTooltip, router]
+  );
+
+  // Si el usuario toca fuera del tooltip, se cierra
+  const handleMapClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
+      if (tooltipRef.current && (event.target instanceof Node) && tooltipRef.current.contains(event.target)) {
+        return;
+      }
+      closeTooltip();
+    },
+    [closeTooltip]
+  );
+
   return (
     <div
       ref={mapRef}
-      className={cn(
-        'relative w-full h-full flex items-center justify-center',
-        'dark:bg-card/30 bg-white/80',
-        'rounded-xl',
-        'dark:border-border/50 border-border/80',
-        'p-4',
-        'dark:shadow-none shadow-sm'
-      )}
+      className="relative w-full h-full flex items-center justify-center p-2 bg-white dark:bg-card/30 rounded-xl border dark:border-border/50 shadow-sm dark:shadow-none"
+      onClick={handleMapClick}
+      onTouchStart={handleMapClick}
     >
       <ComposableMap
-        projection='geoMercator'
-        projectionConfig={{
-          scale: isMobile ? 400 : 600,
-          center: [-65, -40],
-        }}
-        width={isMobile ? 400 : 800}
-        height={isMobile ? 300 : 600}
-        className='w-full h-full'
+        projection="geoMercator"
+        projectionConfig={{ scale: isMobile ? 400 : 600, center: [-65, -40] }}
+        width={width}
+        height={height}
+        className="w-full h-full"
       >
-        <ZoomableGroup
-          center={[-65, -40]}
-          zoom={1}
-          minZoom={1}
-          maxZoom={8}
-        >
+        <ZoomableGroup center={[-65, -40]} zoom={1} minZoom={1} maxZoom={8}>
           <Geographies geography={geoUrl}>
-            {({ geographies }: { geographies: any[] }) =>
+            {({ geographies }) =>
               geographies.map((geo) => (
                 <Geography
                   key={geo.rsmKey}
                   geography={geo}
-                  className={cn(
-                    'dark:fill-muted/20',
-                    'fill-muted/60',
-                    'dark:stroke-border',
-                    'stroke-border',
-                    'transition-colors duration-200'
-                  )}
+                  className="fill-muted/60 dark:fill-muted/20 stroke-border dark:stroke-border transition-colors duration-200"
                   strokeWidth={0.8}
                   style={{
                     default: { outline: 'none' },
-                    hover: {
-                      fill: 'hsl(var(--muted)/0.8)',
-                      transition: 'all 250ms',
-                    },
+                    hover: { fill: 'hsl(var(--muted)/0.8)', transition: 'all 250ms' },
                     pressed: { outline: 'none' },
                   }}
                 />
               ))
             }
           </Geographies>
-          {communities
-            .filter((community) => community.location)
-            .map((community, index) => (
+          {clusters.map((cluster, index) => {
+          // Verificamos que la función invert esté definida
+          if (!projection.invert) return null;
+          const geoCoords = projection.invert([cluster.x, cluster.y]);
+          if (!geoCoords) return null;
+          
+          if (cluster.communities.length === 1) {
+            const community = cluster.communities[0];
+            return (
               <Marker
                 key={community.slug}
-                coordinates={[community.location.lng, community.location.lat]}
+                coordinates={[community.location!.lng, community.location!.lat]}
               >
                 <motion.circle
-                  r={isMobile ? 3 : 4}
-                  className={cn(
-                    'dark:fill-primary fill-primary',
-                    'dark:stroke-background/80 stroke-white',
-                    'hover:fill-accent dark:hover:fill-accent',
-                    'cursor-pointer'
-                  )}
-                  strokeWidth={2}
+                  r={isMobile ? 4 : 5}
+                  className="fill-primary dark:fill-primary stroke-white dark:stroke-background/80 cursor-pointer"
+                  strokeWidth={1.5}
                   initial={{ scale: 0, opacity: 0 }}
                   animate={{ scale: 1, opacity: 1 }}
-                  transition={{
-                    type: 'spring',
-                    stiffness: 260,
-                    damping: 20,
-                    delay: index * 0.1
-                  }}
-                  onClick={() => handleMarkerClick(community.slug)}
-                  onMouseEnter={(e) => handleMarkerMouseEnter(e, community)}
-                  onMouseLeave={handleMarkerMouseLeave}
+                  transition={{ type: 'spring', stiffness: 260, damping: 20, delay: index * 0.05 }}
+                  onClick={(e) => handleMarkerClick(e, { type: 'single', community })}
                 />
               </Marker>
-            ))
+            );
+          } else {
+            return (
+              <Marker key={`cluster-${index}`} coordinates={geoCoords}>
+                <motion.g
+                  className="cursor-pointer"
+                  onClick={(e) =>
+                    handleMarkerClick(e, { type: 'cluster', communities: cluster.communities })
+                  }
+                >
+                  <motion.circle
+                    r={isMobile ? 8 : 10}
+                    className="fill-primary dark:fill-primary stroke-white dark:stroke-background/80"
+                    strokeWidth={1.5}
+                    initial={{ scale: 0, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    transition={{ type: 'spring', stiffness: 260, damping: 20, delay: index * 0.05 }}
+                  />
+                  <text
+                    textAnchor="middle"
+                    y={isMobile ? 4 : 5}
+                    className="font-bold text-white dark:text-white text-xs pointer-events-none"
+                  >
+                    {cluster.communities.length}
+                  </text>
+                </motion.g>
+              </Marker>
+            );
           }
+        })}
+
         </ZoomableGroup>
       </ComposableMap>
 
       <AnimatePresence>
         {tooltipContent && (
           <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 10 }}
-            transition={{
-              duration: 0.2,
-              ease: 'easeOut',
-            }}
-            className={cn(
-              'pointer-events-none absolute z-50',
-              'max-w-[200px] min-w-[120px]',
-              'dark:bg-popover/90 bg-popover/95',
-              'dark:border-border/50 border-border/60',
-              'rounded-lg',
-              'dark:shadow-xl shadow-md',
-              'p-3 px-4',
-              'transform-gpu'
-            )}
-            style={{
-              position: 'absolute',
-              left: `${tooltipPosition.x}px`,
-              top: `${tooltipPosition.y}px`,
-              transform: 'translate(-50%, -100%)',
-            }}
+            ref={tooltipRef}
+            initial={{ opacity: 0, y: 10, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 10, scale: 0.95 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+            className="absolute z-50 bg-popover/95 dark:bg-popover/90 border border-border/60 dark:border-border/50 rounded-lg shadow-md dark:shadow-xl p-3 px-4 max-w-[250px] min-w-[150px] pointer-events-auto"
+            style={{ left: `${tooltipPosition.x}px`, top: `${tooltipPosition.y}px`, transform: 'translate(-50%, -110%)' }}
           >
-            <div className='flex flex-col gap-1'>
-              <p className={cn(
-                'font-medium text-sm',
-                'dark:text-foreground/90 text-foreground',
-                'tracking-tight'
-              )}>
-                {tooltipContent.name}
-              </p>
-              <p className={cn(
-                'text-xs flex items-center gap-1',
-                'dark:text-muted-foreground text-muted-foreground/80'
-              )}>
-                <span className={cn(
-                  'size-1.5 rounded-full',
-                  'dark:bg-primary/80 bg-primary/90'
-                )} />
-                {tooltipContent.location}
-              </p>
-            </div>
+            <button
+              className="absolute top-1 right-1 text-muted-foreground hover:text-foreground"
+              onClick={closeTooltip}
+            >
+              <p>x</p>
+            </button>
+            {tooltipContent.type === 'single' ? (
+              <div className="flex flex-col gap-2">
+                <p className="font-medium text-sm dark:text-foreground text-foreground">
+                  {tooltipContent.community.name}
+                </p>
+                <p className="text-xs flex items-center gap-1 dark:text-muted-foreground text-muted-foreground">
+                  <span className="w-2 h-2 rounded-full bg-primary dark:bg-primary" />
+                  {tooltipContent.community.province}
+                </p>
+                <button
+                  onClick={() =>
+                    navigateToCommunity(formatCommunityName(tooltipContent.community.name))
+                  }
+                  className="mt-2 px-3 py-1 text-xs bg-primary text-white rounded hover:bg-primary/90 transition-colors"
+                >
+                  Seleccionar
+                </button>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {tooltipContent.communities.map((comm: Community) => (
+                  <div
+                    key={comm.name}
+                    className="cursor-pointer hover:underline p-1 rounded hover:bg-muted/10 transition-colors"
+                    onClick={() => navigateToCommunity(formatCommunityName(comm.name))}
+                  >
+                    <p className="font-medium text-sm dark:text-foreground text-foreground">
+                      {comm.name}
+                    </p>
+                    <p className="text-xs dark:text-muted-foreground text-muted-foreground">
+                      {comm.province}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
           </motion.div>
         )}
       </AnimatePresence>

--- a/components/CommunityList.tsx
+++ b/components/CommunityList.tsx
@@ -79,7 +79,11 @@ function CommunityDescription({ community }: { community: Community }) {
             aria-label='Twitter'
             onClick={(e) => {
               e.preventDefault();
-              window.open(`https://x.com/${community.twitter}`, '_blank', 'noopener,noreferrer');
+              window.open(
+                `https://x.com/${community.twitter}`,
+                '_blank',
+                'noopener,noreferrer'
+              );
             }}
           >
             <XformerlyTwitter className='h-4 w-4' />
@@ -104,7 +108,8 @@ function CommunityCard({ community, isHovered }: CommunityCardProps) {
         'dark:border-border/50 border-border/20',
         'transition-all duration-300 ease-out',
         'hover:bg-accent/5',
-        (localHovered || isHovered) && 'ring-2 ring-primary/50 ring-offset-2 ring-offset-background shadow-lg'
+        (localHovered || isHovered) &&
+          'ring-2 ring-primary/50 ring-offset-2 ring-offset-background shadow-lg'
       )}
     >
       <motion.div layout className='flex-none'>
@@ -133,7 +138,9 @@ export default function CommunityList({
 
   return (
     <div className='space-y-8'>
+      {/* Agregamos una key al contenedor UL, aunque normalmente no es obligatorio si no forma parte de otro map */}
       <motion.ul
+        key="community-list"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'
@@ -156,17 +163,23 @@ export default function CommunityList({
 
       {totalPages > 1 && (
         <Pagination className='flex justify-center pt-8'>
-          <PaginationContent className={cn(
-            'rounded-lg border p-2',
-            'dark:bg-card/30 bg-white',
-            'dark:border-border/50 border-border/20'
-          )}>
+          <PaginationContent
+            className={cn(
+              'rounded-lg border p-2',
+              'dark:bg-card/30 bg-white',
+              'dark:border-border/50 border-border/20'
+            )}
+          >
             <PaginationItem>
               <PaginationPrevious
-                onClick={() => currentPage > 1 && handlePageChange(currentPage - 1)}
+                onClick={() => {
+                  if (currentPage > 1) handlePageChange(currentPage - 1);
+                }}
                 className={cn(
                   'cursor-pointer',
-                  currentPage === 1 ? 'pointer-events-none opacity-50 cursor-not-allowed' : ''
+                  currentPage === 1
+                    ? 'pointer-events-none opacity-50 cursor-not-allowed'
+                    : ''
                 )}
               />
             </PaginationItem>
@@ -176,7 +189,7 @@ export default function CommunityList({
                 <PaginationLink
                   onClick={() => handlePageChange(page)}
                   isActive={currentPage === page}
-                  className="cursor-pointer"
+                  className='cursor-pointer'
                 >
                   {page}
                 </PaginationLink>
@@ -185,10 +198,14 @@ export default function CommunityList({
 
             <PaginationItem>
               <PaginationNext
-                onClick={() => currentPage < totalPages && handlePageChange(currentPage + 1)}
+                onClick={() => {
+                  if (currentPage < totalPages) handlePageChange(currentPage + 1);
+                }}
                 className={cn(
                   'cursor-pointer',
-                  currentPage === totalPages ? 'pointer-events-none opacity-50 cursor-not-allowed' : ''
+                  currentPage === totalPages
+                    ? 'pointer-events-none opacity-50 cursor-not-allowed'
+                    : ''
                 )}
               />
             </PaginationItem>

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "react-dom": "^18",
         "react-hook-form": "^7.54.1",
         "react-resizable-panels": "^2.1.7",
-        "react-simple-maps": "^3.0.0",
+        "react-simple-maps": "^1.0.0",
         "recharts": "2.15.0",
         "sonner": "^1.7.1",
         "tailwind-merge": "^2.5.5",
@@ -2255,28 +2255,13 @@
       }
     },
     "node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
-    },
-    "node_modules/d3-dispatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
-      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
-    },
-    "node_modules/d3-drag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
-      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
-      "dependencies": {
-        "d3-dispatch": "1 - 2",
-        "d3-selection": "2"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
-    },
-    "node_modules/d3-ease": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
-      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
     },
     "node_modules/d3-format": {
       "version": "3.1.0",
@@ -2287,19 +2272,30 @@
       }
     },
     "node_modules/d3-geo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
-      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
+      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^2.5.0"
+        "d3-array": "1"
       }
     },
+    "node_modules/d3-geo/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
       "dependencies": {
-        "d3-color": "1 - 2"
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-path": {
@@ -2324,11 +2320,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/d3-selection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -2361,38 +2352,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
-      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
-    },
-    "node_modules/d3-transition": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
-      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
-      "dependencies": {
-        "d3-color": "1 - 2",
-        "d3-dispatch": "1 - 2",
-        "d3-ease": "1 - 2",
-        "d3-interpolate": "1 - 2",
-        "d3-timer": "1 - 2"
-      },
-      "peerDependencies": {
-        "d3-selection": "2"
-      }
-    },
-    "node_modules/d3-zoom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
-      "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
-      "dependencies": {
-        "d3-dispatch": "1 - 2",
-        "d3-drag": "2",
-        "d3-interpolate": "1 - 2",
-        "d3-selection": "2",
-        "d3-transition": "2"
       }
     },
     "node_modules/date-fns": {
@@ -3413,19 +3372,18 @@
       }
     },
     "node_modules/react-simple-maps": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-3.0.0.tgz",
-      "integrity": "sha512-vKNFrvpPG8Vyfdjnz5Ne1N56rZlDfHXv5THNXOVZMqbX1rWZA48zQuYT03mx6PAKanqarJu/PDLgshIZAfHHqw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-1.0.0.tgz",
+      "integrity": "sha512-2A/yRZdMRr5VFwR4SFqIfZggSsPQ/ABvx7wyOFnvYqtbpxP5XEXPsFt/NH055lcrOj4qeUtHgPsDocAl86GmnA==",
+      "license": "MIT",
       "dependencies": {
-        "d3-geo": "^2.0.2",
-        "d3-selection": "^2.0.0",
-        "d3-zoom": "^2.0.0",
-        "topojson-client": "^3.1.0"
+        "d3-geo": "^1.11.6",
+        "topojson-client": "^3.0.0"
       },
       "peerDependencies": {
         "prop-types": "^15.7.2",
-        "react": "^16.8.0 || 17.x || 18.x",
-        "react-dom": "^16.8.0 || 17.x || 18.x"
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0"
       }
     },
     "node_modules/react-smooth": {
@@ -4117,17 +4075,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.54.1",
     "react-resizable-panels": "^2.1.7",
-    "react-simple-maps": "^3.0.0",
+    "react-simple-maps": "^1.0.0",
     "recharts": "2.15.0",
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",

--- a/utils/fetchCommunities.ts
+++ b/utils/fetchCommunities.ts
@@ -16,14 +16,21 @@ export async function fetchCommunities(): Promise<Community[]> {
 export async function fetchCommunityBySlug(
   slug: string
 ): Promise<Community | null> {
+  if (!slug) {
+    console.error("Error: slug is undefined or empty");
+    return null; 
+  }
+
   try {
-    const dataDirectory = path.join(
-      process.cwd(),
-      "public",
-      "data",
-      "communities"
-    );
+    const dataDirectory = path.join(process.cwd(), "public", "data", "communities");
     const filePath = path.join(dataDirectory, `${slug}.json`);
+    
+    const fileExists = await fs.stat(filePath).catch(() => false);
+    if (!fileExists) {
+      console.error(`Error: File for community with slug ${slug} does not exist`);
+      return null;
+    }
+
     const fileContents = await fs.readFile(filePath, "utf8");
     const community = JSON.parse(fileContents) as Community;
     community.slug = slug;


### PR DESCRIPTION
There was an "UX" error in the page, when i was on the map. In Buenos Aires, there were a lot of communities and they were all in front of each other, being imposible to see. So I fixed that, in an efficient way. Also I solved navigateToCommunity errors, that was giving undefined.

New way: 
![image](https://github.com/user-attachments/assets/c1ffcc5d-c026-47b9-8b77-87748aa99e2a)

Old way: 
![image](https://github.com/user-attachments/assets/83ebb5e8-3e22-4b06-bac5-d8ff3aa96769)
